### PR TITLE
refactor: add gitlint pre-commit hook

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,25 @@
+[general]
+# Ignore following rules
+ignore=body-is-missing
+# verbosity should be a value between 1 and 3, the commandline -v flags take precedence over this
+verbosity = 2
+# By default gitlint will ignore merge commits. Set to 'false' to disable.
+ignore-merge-commits=true
+
+contrib = contrib-title-conventional-commits
+
+[title-max-length]
+line-length=72
+
+[title-must-not-contain-word]
+# Comma-separated list of words that should not occur in the title. Matching is case
+# insensitive. It's fine if the keyword occurs as part of a larger word (so "WIPING"
+# will not cause a violation, but "WIP: my title" will.
+words=WIP
+
+[body-max-line-length]
+line-length=80
+
+[body-min-length]
+# If commit body exists, no min length is required for it
+min-length=0

--- a/.gitlint
+++ b/.gitlint
@@ -15,7 +15,7 @@ line-length=72
 # Comma-separated list of words that should not occur in the title. Matching is case
 # insensitive. It's fine if the keyword occurs as part of a larger word (so "WIPING"
 # will not cause a violation, but "WIP: my title" will.
-words=WIP
+words=WIP,kre,kdl
 
 [body-max-line-length]
 line-length=80

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,7 @@ repos:
         - --chart-search-root=./helm/kai
         - --template-files=CHART.md.gotmpl
         - --output-file=CHART.md
+- repo: https://github.com/jorisroovers/gitlint
+  rev: v0.19.1
+  hooks:
+    - id: gitlint

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ In order to start development on this project you will need these tools:
 - **[helm](https://helm.sh/)**: K8s package manager. Make sure you have v3+
 - **[helm-docs](https://github.com/norwoodj/helm-docs)**: Helm doc auto-generation tool
 - **[yq](https://github.com/mikefarah/yq)**: YAML processor. Make sure you have v4+
+- **[gitlint](https://jorisroovers.com/gitlint)**: Checks your commit messages for style.
 - **[pre-commit](https://pre-commit.com/)**: Pre-commit hooks execution tool ensures the best practices are followed before commiting any change
 
 ## Pre-commit hooks setup
@@ -139,6 +140,7 @@ From the repository root execute the following commands:
 ```bash
 pre-commit install
 pre-commit install-hooks
+pre-commit install --hook-type commit-msg
 ```
 
 **Note**: Contributing commits that had not passed the required hooks will be rejected.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add **gitlint** to pre-commit configuration. 

## Motivation and Context
As this repo is currently following [Conventional Commit](https://www.conventionalcommits.org) specification we need to ensure that commit messages follow this compliance. So [gitlint](https://jorisroovers.com/gitlint) has been added to pre-commit configuration to ensure the correction of the commit messages.

The following rules override the default gitlint config:
* Conventional commit format is mandatory
* Title line length >5, < 72.
* Body lines length <80.
* Empty body is allowed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other changes (ci configuration, documentation or any other kind of changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have created tests for my code changes, and the tests are passing.
- [X] I have executed the pre-commit hooks locally.
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).
- [X] I have updated the documentation accordingly.
