### PR TITLE
fix: rename k8s-manager env vars prefix from kre to kai

### DIFF
--- a/helm/kai/templates/engine/k8s-manager/configmap.yaml
+++ b/helm/kai/templates/engine/k8s-manager/configmap.yaml
@@ -5,21 +5,21 @@ metadata:
   labels:
     {{- include "k8s-manager.labels" . | nindent 4 }}
 data:
-  KRE_API_LOG_LEVEL: {{ .Values.adminApi.logLevel }}
-  KRE_DEVELOPMENT_MODE: "{{ .Values.developmentMode }}"
-  KRE_RELEASE_NAME: "{{ .Release.Name }}"
-  KRE_BASE_DOMAIN_NAME: {{ .Values.config.baseDomainName }}
-  KRE_ENTRYPOINTS_REQUEST_TIMEOUT: "30"
-  KRE_ENTRYPOINTS_BASE64_INGRESSES_ANNOTATIONS: {{ .Values.k8sManager.generatedEntrypoints.ingress.annotations | toYaml | b64enc }}
-  KRE_ENTRYPOINTS_TLS: "{{ .Values.k8sManager.generatedEntrypoints.tls }}"
+  KAI_API_LOG_LEVEL: {{ .Values.adminApi.logLevel }}
+  KAI_DEVELOPMENT_MODE: "{{ .Values.developmentMode }}"
+  KAI_RELEASE_NAME: "{{ .Release.Name }}"
+  KAI_BASE_DOMAIN_NAME: {{ .Values.config.baseDomainName }}
+  KAI_ENTRYPOINTS_REQUEST_TIMEOUT: "30"
+  KAI_ENTRYPOINTS_BASE64_INGRESSES_ANNOTATIONS: {{ .Values.k8sManager.generatedEntrypoints.ingress.annotations | toYaml | b64enc }}
+  KAI_ENTRYPOINTS_TLS: "{{ .Values.k8sManager.generatedEntrypoints.tls }}"
     {{- if and .Values.k8sManager.generatedEntrypoints.tls .Values.k8sManager.generatedEntrypoints.ingress.tls.secretName }}
-  KRE_ENTRYPOINTS_TLS_CERT_SECRET_NAME: {{ .Values.k8sManager.generatedEntrypoints.ingress.tls.secretName }}
+  KAI_ENTRYPOINTS_TLS_CERT_SECRET_NAME: {{ .Values.k8sManager.generatedEntrypoints.ingress.tls.secretName }}
   {{- end }}
   {{- if .Values.k8sManager.generatedEntrypoints.ingress.className }}
-  KRE_ENTRYPOINTS_INGRESS_CLASS_NAME: {{ .Values.k8sManager.generatedEntrypoints.ingress.className }}
+  KAI_ENTRYPOINTS_INGRESS_CLASS_NAME: {{ .Values.k8sManager.generatedEntrypoints.ingress.className }}
   {{- end }}
-  KRE_NATS_URL: "{{ include "nats.url" . }}"
-  KRE_NATS_HOST: "{{ include "nats.host" . }}"
-  KRE_KRT_FILES_DOWNLOADER_IMAGE: "{{ .Values.k8sManager.krtFilesDownloader.image.repository }}"
-  KRE_KRT_FILES_DOWNLOADER_TAG: "{{ .Values.k8sManager.krtFilesDownloader.image.tag }}"
-  KRE_KRT_FILES_DOWNLOADER_PULL_POLICY: "{{ .Values.k8sManager.krtFilesDownloader.image.pullPolicy }}"
+  KAI_NATS_URL: "{{ include "nats.url" . }}"
+  KAI_NATS_HOST: "{{ include "nats.host" . }}"
+  KAI_KRT_FILES_DOWNLOADER_IMAGE: "{{ .Values.k8sManager.krtFilesDownloader.image.repository }}"
+  KAI_KRT_FILES_DOWNLOADER_TAG: "{{ .Values.k8sManager.krtFilesDownloader.image.tag }}"
+  KAI_KRT_FILES_DOWNLOADER_PULL_POLICY: "{{ .Values.k8sManager.krtFilesDownloader.image.pullPolicy }}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

k8s-manager now expects env vars with KAI as prefix instead of KRE

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other changes (ci configuration, documentation or any other kind of changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have created tests for my code changes, and the tests are passing.
- [ ] I have executed the pre-commit hooks locally.
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).
- [ ] I have updated the documentation accordingly.
