### PR TITLE
fix(helm): process registry pvc storage class cannot be set

### DIFF
--- a/helm/kai/CHART.md
+++ b/helm/kai/CHART.md
@@ -12,30 +12,30 @@
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| adminApi.affinity | object | `{}` | Assign custom affinity rules to the Admin API pods # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # |
+| adminApi.affinity | object | `{}` | Assign custom affinity rules to the Admin API pods |
 | adminApi.host | string | `"api.kai.local"` | Hostname |
 | adminApi.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | adminApi.image.repository | string | `"konstellation/kai-admin-api"` | Image repository |
-| adminApi.image.tag | string | `"0.2.0-develop.21"` | Image tag |
+| adminApi.image.tag | string | `"0.2.0-develop.24"` | Image tag |
 | adminApi.ingress.annotations | object | See `adminApi.ingress.annotations` in [values.yaml](./values.yaml) | Ingress annotations |
 | adminApi.ingress.className | string | `"kong"` | The name of the ingress class to use |
 | adminApi.logLevel | string | `"INFO"` | Default application log level |
-| adminApi.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. # ref: https://kubernetes.io/docs/user-guide/node-selection/ # |
+| adminApi.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. |
 | adminApi.storage.class | string | `"standard"` | Storage class name |
 | adminApi.storage.path | string | `"/admin-api-files"` | Persistent volume mount point. This will define Admin API app workdir too. |
 | adminApi.storage.size | string | `"1Gi"` | Storage class size |
 | adminApi.tls.enabled | bool | `false` | Whether to enable TLS |
-| adminApi.tolerations | list | `[]` | Tolerations for use with node taints # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ # |
-| chronograf.affinity | object | `{}` | Assign custom affinity rules to the Chronograf pods # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # |
+| adminApi.tolerations | list | `[]` | Tolerations for use with node taints |
+| chronograf.affinity | object | `{}` | Assign custom affinity rules to the Chronograf pods |
 | chronograf.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | chronograf.image.repository | string | `"chronograf"` | Image repository |
 | chronograf.image.tag | string | `"1.8.4"` | Image tag |
-| chronograf.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. # ref: https://kubernetes.io/docs/user-guide/node-selection/ # |
+| chronograf.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. |
 | chronograf.persistence.accessMode | string | `"ReadWriteOnce"` | Access mode for the volume |
 | chronograf.persistence.enabled | bool | `true` | Whether to enable persistence |
 | chronograf.persistence.size | string | `"2Gi"` | Storage size |
 | chronograf.persistence.storageClass | string | `"standard"` | Storage class name |
-| chronograf.tolerations | list | `[]` | Tolerations for use with node taints # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ # |
+| chronograf.tolerations | list | `[]` | Tolerations for use with node taints |
 | config.admin.apiHost | string | `"api.kai.local"` | Api Hostname for Admin UI and Admin API |
 | config.admin.corsEnabled | bool | `true` | Whether to enable CORS on Admin API |
 | config.baseDomainName | string | `"local"` | Base domain name for Admin API and K8S Manager apps |
@@ -51,26 +51,26 @@
 | config.s3.region | string | us-east-1 | The Region in which the buckets are created. This affect to MinIO buckets region if it is enabled |
 | developmentMode | bool | `false` | Whether to setup developement mode |
 | influxdb.address | string | `"http://kai-influxdb/"` |  |
-| influxdb.affinity | object | `{}` | Assign custom affinity rules to the InfluxDB pods # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # |
+| influxdb.affinity | object | `{}` | Assign custom affinity rules to the InfluxDB pods |
 | influxdb.config.http | object | `{"auth-enabled":false,"enabled":true,"flux-enabled":true}` | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#http) |
 | influxdb.image.tag | string | `"1.8.1"` | Image tag |
 | influxdb.initScripts.enabled | bool | `true` | Boolean flag to enable and disable initscripts. See https://github.com/influxdata/helm-charts/tree/master/charts/influxdb#configure-the-chart for more info |
 | influxdb.initScripts.scripts | object | `{"init.iql":"CREATE DATABASE \"kai\"\n"}` | Init scripts |
-| influxdb.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. # ref: https://kubernetes.io/docs/user-guide/node-selection/ # |
+| influxdb.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. |
 | influxdb.persistence.accessMode | string | `"ReadWriteOnce"` | Access mode for the volume |
 | influxdb.persistence.enabled | bool | `true` | Whether to enable persistence. See https://github.com/influxdata/helm-charts/tree/master/charts/influxdb#configure-the-chart for more info |
 | influxdb.persistence.size | string | `"10Gi"` | Storage size |
 | influxdb.persistence.storageClass | string | `"standard"` | Storage class name |
-| influxdb.tolerations | list | `[]` | Tolerations for use with node taints # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ # |
-| k8sManager.affinity | object | `{}` | Assign custom affinity rules to the K8S Manager pods # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # |
+| influxdb.tolerations | list | `[]` | Tolerations for use with node taints |
+| k8sManager.affinity | object | `{}` | Assign custom affinity rules to the K8S Manager pods |
 | k8sManager.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | k8sManager.image.repository | string | `"konstellation/kai-k8s-manager"` | Image repository |
-| k8sManager.image.tag | string | `"0.2.0-develop.21"` | Image tag |
-| k8sManager.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. # ref: https://kubernetes.io/docs/user-guide/node-selection/ # |
+| k8sManager.image.tag | string | `"0.2.0-develop.24"` | Image tag |
+| k8sManager.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. |
 | k8sManager.serviceAccount.annotations | object | `{}` | The Service Account annotations |
 | k8sManager.serviceAccount.create | bool | `true` | Whether to create the Service Account |
 | k8sManager.serviceAccount.name | string | `""` | The name of the service account. @default: A pre-generated name based on the chart relase fullname sufixed by `-k8s-manager` |
-| k8sManager.tolerations | list | `[]` | Tolerations for use with node taints # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ # |
+| k8sManager.tolerations | list | `[]` | Tolerations for use with node taints |
 | k8sManager.triggers.ingress.annotations | string | See `entrypoints.ingress.annotations` in [values.yaml](./values.yaml) | The annotations that all the generated ingresses for the entrypoints will have |
 | k8sManager.triggers.ingress.className | string | `"kong"` | The ingressClassName to use for the enypoints' generated ingresses |
 | k8sManager.triggers.ingress.tls.secretName | string | If not defined, every created ingress will use an autogenerated certificate name based on the deployed runtimeId and .Values.config.baseDomainName. | TLS certificate secret name. If defined, wildcard for the current application domain must be used. |
@@ -151,22 +151,22 @@
 | minio.rootUser | string | Randomly generated value | Sets Root user |
 | minio.service.port | string | `"9000"` |  |
 | minio.service.type | string | `"ClusterIP"` |  |
-| mongoExpress.affinity | object | `{}` | Assign custom affinity rules to the Mongo Express pods # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # |
+| mongoExpress.affinity | object | `{}` | Assign custom affinity rules to the Mongo Express pods |
 | mongoExpress.connectionString.secretKey | string | `""` | The name of the secret key that contains the MongoDB connection string. |
 | mongoExpress.connectionString.secretName | string | `""` | The name of the secret that contains a key with the MongoDB connection string. |
 | mongoExpress.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | mongoExpress.image.repository | string | `"mongo-express"` | Image repository |
 | mongoExpress.image.tag | string | `"0.54.0"` | Image tag |
-| mongoExpress.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. # ref: https://kubernetes.io/docs/user-guide/node-selection/ # |
-| mongoExpress.tolerations | list | `[]` | Tolerations for use with node taints # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ # |
-| mongoWriter.affinity | object | `{}` | Assign custom affinity rules to the Mongo Writter pods # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # |
+| mongoExpress.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. |
+| mongoExpress.tolerations | list | `[]` | Tolerations for use with node taints |
+| mongoWriter.affinity | object | `{}` | Assign custom affinity rules to the Mongo Writter pods |
 | mongoWriter.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | mongoWriter.image.repository | string | `"konstellation/kai-mongo-writer"` | Image repository |
-| mongoWriter.image.tag | string | `"0.2.0-develop.21"` | Image tag |
-| mongoWriter.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. # ref: https://kubernetes.io/docs/user-guide/node-selection/ # |
-| mongoWriter.tolerations | list | `[]` | Tolerations for use with node taints # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ # |
+| mongoWriter.image.tag | string | `"0.2.0-develop.24"` | Image tag |
+| mongoWriter.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. |
+| mongoWriter.tolerations | list | `[]` | Tolerations for use with node taints |
 | nameOverride | string | `""` | Provide a name in place of kai for `app.kubernetes.io/name` labels |
-| nats.affinity | object | `{}` | Assign custom affinity rules to the NATS pods # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # |
+| nats.affinity | object | `{}` | Assign custom affinity rules to the NATS pods |
 | nats.client.port | int | `4222` | Port for client connections |
 | nats.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | nats.image.repository | string | `"nats"` | Image repository |
@@ -190,13 +190,13 @@
 | nats.logging.debug | bool | `false` | Whether to enable logging debug mode |
 | nats.logging.logtime | bool | `true` | Timestamp log entries |
 | nats.logging.trace | bool | `false` | Whether to enable logging trace mode |
-| nats.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. # ref: https://kubernetes.io/docs/user-guide/node-selection/ # |
-| nats.tolerations | list | `[]` | Tolerations for use with node taints # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ # |
+| nats.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. |
+| nats.tolerations | list | `[]` | Tolerations for use with node taints |
 | natsManager.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | natsManager.image.repository | string | `"konstellation/kai-nats-manager"` | Image repository |
-| natsManager.image.tag | string | `"0.2.0-develop.21"` | Image tag |
+| natsManager.image.tag | string | `"0.2.0-develop.24"` | Image tag |
 | rbac.create | bool | `true` | Whether to create the roles for the services that could use custom Service Accounts |
-| registry.affinity | object | `{}` | Assign custom affinity rules to the pods # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # |
+| registry.affinity | object | `{}` | Assign custom affinity rules to the pods |
 | registry.auth.password | string | password | Registry password |
 | registry.auth.user | string | user | Registry username |
 | registry.config | string | `""` | A string contaning the config for Docker Registry. Ref: https://docs.docker.com/registry/configuration/. |
@@ -226,7 +226,7 @@
 | registry.storage.enabled | bool | `true` | Whether to enable persistence |
 | registry.storage.path | string | `"/var/lib/registry"` | Persistent volume mount point. This will define Registry app workdir too. |
 | registry.storage.size | string | `"10Gi"` | Storage size |
-| registry.storage.storageClass | string | `"standard"` | Storage class name |
-| registry.tls | object | `{"enabled":false}` | Define which Nodes the Pods are scheduled on. # ref: https://kubernetes.io/docs/user-guide/node-selection/ # |
+| registry.storage.storageClass | string | `""` | Storage class name |
+| registry.tls | object | `{"enabled":false}` | Define which Nodes the Pods are scheduled on. |
 | registry.tls.enabled | bool | `false` | Whether to enable TLS |
-| registry.tolerations | list | `[]` | Tolerations for use with node taints # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ # |
+| registry.tolerations | list | `[]` | Tolerations for use with node taints |

--- a/helm/kai/templates/engine/registry/pvc.yaml
+++ b/helm/kai/templates/engine/registry/pvc.yaml
@@ -11,4 +11,5 @@ spec:
   resources:
     requests:
       storage: {{ .Values.registry.storage.size }}
+  storageClassName: {{ .Values.registry.storage.storageClass }}
 {{- end }}

--- a/helm/kai/values.yaml
+++ b/helm/kai/values.yaml
@@ -658,7 +658,7 @@ registry:
     # -- Whether to enable persistence
     enabled: true
     # -- Storage class name
-    storageClass: "standard"
+    storageClass: ""
     # -- Access mode for the volume
     accessMode: ReadWriteOnce
     # -- Storage size


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Fix: Process registry PVC storageclass cannot be set via helm values
* If storage class is not set, then cluster's default will be used


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other changes (ci configuration, documentation or any other kind of changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have created tests for my code changes, and the tests are passing.
- [X] I have executed the pre-commit hooks locally.
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).
- [X] I have updated the documentation accordingly.
