### PR TITLE
chore: make Grafana, Loki and Prometheus outsourceable

### DIFF
--- a/helm/kai/CHART.md
+++ b/helm/kai/CHART.md
@@ -4,6 +4,7 @@
 
 | Repository | Name | Version |
 |------------|------|---------|
+| https://charts.bitnami.com/bitnami | redis | 18.2.1 |
 | https://charts.min.io/ | minio | 5.0.14 |
 | https://grafana.github.io/helm-charts | grafana | 7.0.3 |
 | https://grafana.github.io/helm-charts | loki | 5.36.3 |
@@ -15,31 +16,34 @@
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| adminApi.affinity | object | `{}` | Assign custom affinity rules to the Admin API pods # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # |
+| adminApi.affinity | object | `{}` | Assign custom affinity rules to the Admin API pods |
 | adminApi.host | string | `"api.kai.local"` | Hostname. This will be used to create the ingress rule and must be a subdomain of `.config.baseDomainName` |
 | adminApi.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | adminApi.image.repository | string | `"konstellation/kai-admin-api"` | Image repository |
-| adminApi.image.tag | string | `"0.2.0-develop.47"` | Image tag |
+| adminApi.image.tag | string | `"0.2.0-develop.49"` | Image tag |
 | adminApi.ingress.annotations | object | See `adminApi.ingress.annotations` in [values.yaml](./values.yaml) | Ingress annotations |
 | adminApi.ingress.className | string | `"kong"` | The name of the ingress class to use |
 | adminApi.logLevel | string | `"INFO"` | Default application log level |
-| adminApi.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. # ref: https://kubernetes.io/docs/user-guide/node-selection/ # |
+| adminApi.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. |
 | adminApi.storage.class | string | `"standard"` | Storage class name |
 | adminApi.storage.path | string | `"/admin-api-files"` | Persistent volume mount point. This will define Admin API app workdir too. |
 | adminApi.storage.size | string | `"1Gi"` | Storage class size |
-| adminApi.tolerations | list | `[]` | Tolerations for use with node taints # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ # |
-| chronograf.affinity | object | `{}` | Assign custom affinity rules to the Chronograf pods # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # |
+| adminApi.tolerations | list | `[]` | Tolerations for use with node taints |
+| chronograf.affinity | object | `{}` | Assign custom affinity rules to the Chronograf pods |
 | chronograf.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | chronograf.image.repository | string | `"chronograf"` | Image repository |
 | chronograf.image.tag | string | `"1.8.4"` | Image tag |
-| chronograf.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. # ref: https://kubernetes.io/docs/user-guide/node-selection/ # |
+| chronograf.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. |
 | chronograf.persistence.accessMode | string | `"ReadWriteOnce"` | Access mode for the volume |
 | chronograf.persistence.enabled | bool | `true` | Whether to enable persistence |
 | chronograf.persistence.size | string | `"2Gi"` | Storage size |
 | chronograf.persistence.storageClass | string | `"standard"` | Storage class name |
-| chronograf.tolerations | list | `[]` | Tolerations for use with node taints # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ # |
+| chronograf.tolerations | list | `[]` | Tolerations for use with node taints |
 | config.admin.corsEnabled | bool | `true` | Whether to enable CORS on Admin API |
 | config.baseDomainName | string | `"kai.local"` | Base domain name for Admin API and K8S Manager apps |
+| config.loki.datasource | object | `{"jsonData":"{}","uid":""}` | Only when `loki.enabled: true` and `grafana.enabled: true`. Grafana datasource json data config. |
+| config.loki.isDefault | bool | `true` | Only when `loki.enabled: true` and `grafana.enabled: true`. Set loki as default datasource for Grafana. |
+| config.loki.url | string | `"http://{{ include \"loki.fullname\" .Subcharts.loki }}:{{ .Values.loki.loki.server.http_listen_port }}"` | Loki endpoint url. Change this to your own URL when `loki.enabled: false` |
 | config.minio.defaultRegion | string | us-east-1 | Default region (only affect to Minio buckets) |
 | config.minio.tier.aws | object | `{"auth":{"accessKeyID":"","secretAccessKey":"","secretKeyNames":{"accessKey":"","secretKey":""},"secretName":""},"endpointURL":"","region":""}` | Transition Objects from MinIO to AWS S3 |
 | config.minio.tier.aws.auth | object | `{"accessKeyID":"","secretAccessKey":"","secretKeyNames":{"accessKey":"","secretKey":""},"secretName":""}` | AWS authentication config @default: first look for the keys in pre-existing kubernetes secret object (secretName and secretKeyNames), if not set, look for the keys in values.yaml (accessKeyID and secretAccessKey) |
@@ -57,6 +61,9 @@
 | config.minio.tier.remotePrefix | string | DATA | Prefix or path in bucket where object transition will happen (will be created if not exist) |
 | config.mongodb.connectionString.secretKey | string | `""` | The name of the secret key that contains the MongoDB connection string. |
 | config.mongodb.connectionString.secretName | string | `""` | The name of the secret that contains a key with the MongoDB connection string. |
+| config.prometheus.datasource | object | `{"jsonData":"{}"}` | Only when `prometheus.enabled: true` and `grafana.enabled: true`. Grafana datasource json data config. |
+| config.prometheus.isDefault | bool | `false` | Only when `prometheus.enabled: true` and `grafana.enabled: true`. Set prometheus as default datasource for Grafana. |
+| config.prometheus.url | string | `"http://{{ include \"prometheus.fullname\" .Subcharts.prometheus }}-{{ .Values.prometheus.server.name }}:{{ .Values.prometheus.server.service.servicePort }}{{ .Values.prometheus.server.prefixURL }}"` | Prometheus endpoint url. Change this to your own URL when `prometheus.enabled: false` |
 | config.tls.certSecretName | string | `""` | An existing secret containing a valid wildcard certificate for the value provissioned in `.config.baseDomainName`. Required if `config.tls.enabled = true` |
 | config.tls.enabled | bool | `false` | Whether to enable TLS |
 | developmentMode | bool | `false` | Whether to setup developement mode |
@@ -82,26 +89,26 @@
 | grafana.service.type | string | `"ClusterIP"` | Service type |
 | grafana.sidecar | object | `{"datasources":{"enabled":true,"label":"grafana_datasource","labelValue":"1","maxLines":1000}}` | sidecar config (required for datasource config section in loki and prometheus) |
 | influxdb.address | string | `"http://kai-influxdb/"` |  |
-| influxdb.affinity | object | `{}` | Assign custom affinity rules to the InfluxDB pods # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # |
+| influxdb.affinity | object | `{}` | Assign custom affinity rules to the InfluxDB pods |
 | influxdb.config.http | object | `{"auth-enabled":false,"enabled":true,"flux-enabled":true}` | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#http) |
 | influxdb.image.tag | string | `"1.8.1"` | Image tag |
 | influxdb.initScripts.enabled | bool | `true` | Boolean flag to enable and disable initscripts. See https://github.com/influxdata/helm-charts/tree/master/charts/influxdb#configure-the-chart for more info |
 | influxdb.initScripts.scripts | object | `{"init.iql":"CREATE DATABASE \"kai\"\n"}` | Init scripts |
-| influxdb.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. # ref: https://kubernetes.io/docs/user-guide/node-selection/ # |
+| influxdb.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. |
 | influxdb.persistence.accessMode | string | `"ReadWriteOnce"` | Access mode for the volume |
 | influxdb.persistence.enabled | bool | `true` | Whether to enable persistence. See https://github.com/influxdata/helm-charts/tree/master/charts/influxdb#configure-the-chart for more info |
 | influxdb.persistence.size | string | `"10Gi"` | Storage size |
 | influxdb.persistence.storageClass | string | `"standard"` | Storage class name |
-| influxdb.tolerations | list | `[]` | Tolerations for use with node taints # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ # |
-| k8sManager.affinity | object | `{}` | Assign custom affinity rules to the K8S Manager pods # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # |
+| influxdb.tolerations | list | `[]` | Tolerations for use with node taints |
+| k8sManager.affinity | object | `{}` | Assign custom affinity rules to the K8S Manager pods |
 | k8sManager.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | k8sManager.image.repository | string | `"konstellation/kai-k8s-manager"` | Image repository |
-| k8sManager.image.tag | string | `"0.2.0-develop.47"` | Image tag |
-| k8sManager.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. # ref: https://kubernetes.io/docs/user-guide/node-selection/ # |
+| k8sManager.image.tag | string | `"0.2.0-develop.49"` | Image tag |
+| k8sManager.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. |
 | k8sManager.serviceAccount.annotations | object | `{}` | The Service Account annotations |
 | k8sManager.serviceAccount.create | bool | `true` | Whether to create the Service Account |
 | k8sManager.serviceAccount.name | string | `""` | The name of the service account. @default: A pre-generated name based on the chart relase fullname sufixed by `-k8s-manager` |
-| k8sManager.tolerations | list | `[]` | Tolerations for use with node taints # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ # |
+| k8sManager.tolerations | list | `[]` | Tolerations for use with node taints |
 | k8sManager.triggers.ingress.annotations | string | See `entrypoints.ingress.annotations` in [values.yaml](./values.yaml) | The annotations that all the generated ingresses for the entrypoints will have |
 | k8sManager.triggers.ingress.className | string | `"kong"` | The ingressClassName to use for the enypoints' generated ingresses |
 | kapacitor.enabled | bool | `false` | Whether to enable Kapacitor |
@@ -161,10 +168,8 @@
 | keycloak.serviceAccount.create | bool | `true` |  |
 | keycloak.serviceAccount.name | string | `""` |  |
 | keycloak.tolerations | list | `[]` | Assign custom tolerations to the Keycloak pods |
-| loki.datasource | object | `{"jsonData":"{}","uid":""}` | grafana datasource json data config |
 | loki.enabled | bool | `true` | Whether to enable Loki |
 | loki.gateway.enabled | bool | `false` | Specifies whether the gateway should be enabled |
-| loki.isDefault | bool | `true` | Set loki as default datasource |
 | loki.loki.auth_enabled | bool | `false` | Should authentication be enabled |
 | loki.loki.commonConfig | object | `{"replication_factor":1}` | monolithic loki |
 | loki.loki.image.tag | string | `"2.9.2"` | Loki version |
@@ -180,7 +185,6 @@
 | loki.monitoring.selfMonitoring | object | `{"enabled":false,"grafanaAgent":{"installOperator":false}}` | scrape its own Loki logs |
 | loki.singleBinary.replicas | int | `1` |  |
 | loki.test.enabled | bool | `false` |  |
-| loki.url | string | `"http://{{ include \"loki.fullname\" .Subcharts.loki }}:{{ .Values.loki.loki.server.http_listen_port }}"` | Loki endpoint url |
 | minio.consoleIngress.annotations | object | `{}` | Ingress annotations |
 | minio.consoleIngress.enabled | bool | `true` | Enable ingress for MinIO Web Console |
 | minio.consoleIngress.hosts | list | `["storage-console.kai.local"]` | Ingress hostnames |
@@ -212,22 +216,22 @@
 | minio.rootUser | string | Randomly generated value | Sets Root user |
 | minio.service.port | string | `"9000"` | Internal port number for MinIO S3 API service |
 | minio.service.type | string | `"ClusterIP"` | Service type |
-| mongoExpress.affinity | object | `{}` | Assign custom affinity rules to the Mongo Express pods # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # |
+| mongoExpress.affinity | object | `{}` | Assign custom affinity rules to the Mongo Express pods |
 | mongoExpress.connectionString.secretKey | string | `""` | The name of the secret key that contains the MongoDB connection string. |
 | mongoExpress.connectionString.secretName | string | `""` | The name of the secret that contains a key with the MongoDB connection string. |
 | mongoExpress.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | mongoExpress.image.repository | string | `"mongo-express"` | Image repository |
 | mongoExpress.image.tag | string | `"0.54.0"` | Image tag |
-| mongoExpress.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. # ref: https://kubernetes.io/docs/user-guide/node-selection/ # |
-| mongoExpress.tolerations | list | `[]` | Tolerations for use with node taints # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ # |
-| mongoWriter.affinity | object | `{}` | Assign custom affinity rules to the Mongo Writter pods # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # |
+| mongoExpress.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. |
+| mongoExpress.tolerations | list | `[]` | Tolerations for use with node taints |
+| mongoWriter.affinity | object | `{}` | Assign custom affinity rules to the Mongo Writter pods |
 | mongoWriter.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | mongoWriter.image.repository | string | `"konstellation/kai-mongo-writer"` | Image repository |
-| mongoWriter.image.tag | string | `"0.2.0-develop.47"` | Image tag |
-| mongoWriter.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. # ref: https://kubernetes.io/docs/user-guide/node-selection/ # |
-| mongoWriter.tolerations | list | `[]` | Tolerations for use with node taints # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ # |
+| mongoWriter.image.tag | string | `"0.2.0-develop.49"` | Image tag |
+| mongoWriter.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. |
+| mongoWriter.tolerations | list | `[]` | Tolerations for use with node taints |
 | nameOverride | string | `""` | Provide a name in place of kai for `app.kubernetes.io/name` labels |
-| nats.affinity | object | `{}` | Assign custom affinity rules to the NATS pods # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # |
+| nats.affinity | object | `{}` | Assign custom affinity rules to the NATS pods |
 | nats.client.port | int | `4222` | Port for client connections |
 | nats.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | nats.image.repository | string | `"nats"` | Image repository |
@@ -251,20 +255,18 @@
 | nats.logging.debug | bool | `false` | Whether to enable logging debug mode |
 | nats.logging.logtime | bool | `true` | Timestamp log entries |
 | nats.logging.trace | bool | `false` | Whether to enable logging trace mode |
-| nats.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. # ref: https://kubernetes.io/docs/user-guide/node-selection/ # |
-| nats.tolerations | list | `[]` | Tolerations for use with node taints # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ # |
+| nats.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. |
+| nats.tolerations | list | `[]` | Tolerations for use with node taints |
 | natsManager.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | natsManager.image.repository | string | `"konstellation/kai-nats-manager"` | Image repository |
-| natsManager.image.tag | string | `"0.2.0-develop.47"` | Image tag |
+| natsManager.image.tag | string | `"0.2.0-develop.49"` | Image tag |
 | prometheus.alertmanager.enabled | bool | `true` | Whether to enable alertmanager |
 | prometheus.alertmanager.image.tag | string | `"v0.26.0"` | alertmanager server version |
 | prometheus.alertmanager.persistence.accessModes | list | `["ReadWriteOnce"]` | Access mode for the volume |
 | prometheus.alertmanager.persistence.enabled | bool | `true` |  |
-| prometheus.alertmanager.persistence.size | string | `"4Gi"` | Storage size |
+| prometheus.alertmanager.persistence.size | string | `"2Gi"` | Storage size |
 | prometheus.alertmanager.persistence.storageClass | string | `""` | Storage class name |
-| prometheus.datasource | object | `{"jsonData":"{}"}` | grafana datasource json data config |
 | prometheus.enabled | bool | `true` | Whether to enable Prometheus |
-| prometheus.isDefault | bool | `false` | Set prometheus as default datasource |
 | prometheus.kube-state-metrics.enabled | bool | `false` |  |
 | prometheus.prometheus-node-exporter.enabled | bool | `false` |  |
 | prometheus.prometheus-pushgateway.enabled | bool | `false` |  |
@@ -282,9 +284,37 @@
 | prometheus.server.persistentVolume.storageClass | string | `""` | Storage class name |
 | prometheus.server.service.servicePort | int | `80` | Internal port number for grafana service |
 | prometheus.server.service.type | string | `"ClusterIP"` | Service type |
-| prometheus.url | string | `"http://{{ include \"prometheus.fullname\" .Subcharts.prometheus }}-{{ .Values.prometheus.server.name }}:{{ .Values.prometheus.server.service.servicePort }}{{ .Values.prometheus.server.prefixURL }}"` | Prometheus endpoint url |
 | rbac.create | bool | `true` | Whether to create the roles for the services that could use custom Service Accounts |
-| registry.affinity | object | `{}` | Assign custom affinity rules to the pods # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # |
+| redis.architecture | string | `"standalone"` | architecture. Allowed values: `standalone` or `replication` |
+| redis.auth.enabled | bool | `true` |  |
+| redis.auth.existingSecret | string | `""` | The name of an existing secret with Redis credentials |
+| redis.auth.existingSecretPasswordKey | string | `""` | Password key to be retrieved from existing secret |
+| redis.auth.password | string | `""` |  |
+| redis.enabled | bool | `true` | Whether to enable redis |
+| redis.image.tag | string | `"7.2.3-debian-11-r0"` | Redis server version |
+| redis.master | object | `{"containerPorts":{"redis":6379},"persistence":{"accessModes":["ReadWriteOnce"],"enabled":true,"size":"2Gi","storageClass":""},"service":{"ports":{"redis":6379},"type":"ClusterIP"}}` | number of replicas |
+| redis.master.containerPorts | object | `{"redis":6379}` | redis Container port to open on master nodes |
+| redis.master.persistence.accessModes | list | `["ReadWriteOnce"]` | Access mode for the volume |
+| redis.master.persistence.size | string | `"2Gi"` | Storage size |
+| redis.master.persistence.storageClass | string | `""` | Storage class name |
+| redis.master.service.ports | object | `{"redis":6379}` | Internal port number for master redis service |
+| redis.master.service.type | string | `"ClusterIP"` | Service type |
+| redis.metrics.enabled | bool | `false` | Start a sidecar prometheus exporter to expose redis metrics |
+| redis.replica.autoscaling.enabled | bool | `false` |  |
+| redis.replica.autoscaling.maxReplicas | int | `5` | Max replicas for the pod autoscaling |
+| redis.replica.autoscaling.minReplicas | int | `1` | Min replicas for the pod autoscaling |
+| redis.replica.persistence.accessModes | list | `["ReadWriteOnce"]` | Access mode for the volume |
+| redis.replica.persistence.enabled | bool | `true` |  |
+| redis.replica.persistence.size | string | `"2Gi"` | Storage size |
+| redis.replica.persistence.storageClass | string | `""` | Storage class name |
+| redis.replica.replicaCount | int | `1` | Number of replicas |
+| redis.replica.service.ports | object | `{"redis":6379}` | Internal port number for master redis service |
+| redis.replica.service.type | string | `"ClusterIP"` | Service type |
+| redis.tls.authClients | bool | `false` | Require clients to authenticate |
+| redis.tls.autoGenerated | bool | `false` | Enable autogenerated certificates |
+| redis.tls.enabled | bool | `false` | Enabled Enable TLS traffic |
+| redis.tls.existingSecret | string | `""` | The name of the existing secret that contains the TLS certificates |
+| registry.affinity | object | `{}` | Assign custom affinity rules to the pods |
 | registry.auth.password | string | password | Registry password |
 | registry.auth.user | string | user | Registry username |
 | registry.config | string | `""` | A string contaning the config for Docker Registry. Ref: https://docs.docker.com/registry/configuration/. |
@@ -300,7 +330,7 @@
 | registry.imagePullSecrets | list | `[]` | Image pull secrets |
 | registry.ingress.annotations | object | See `adminApi.ingress.annotations` in [values.yaml](./values.yaml) | Ingress annotations |
 | registry.ingress.className | string | `"kong"` | The name of the ingress class to use |
-| registry.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. # ref: https://kubernetes.io/docs/user-guide/node-selection/ # |
+| registry.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. |
 | registry.podAnnotations | object | `{}` | Pod annotations |
 | registry.podSecurityContext | object | `{}` | Pod security context |
 | registry.resources | object | `{}` | Container resources |
@@ -315,4 +345,4 @@
 | registry.storage.path | string | `"/var/lib/registry"` | Persistent volume mount point. This will define Registry app workdir too. |
 | registry.storage.size | string | `"10Gi"` | Storage size |
 | registry.storage.storageClass | string | `""` | Storage class name |
-| registry.tolerations | list | `[]` | Tolerations for use with node taints # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ # |
+| registry.tolerations | list | `[]` | Tolerations for use with node taints |

--- a/helm/kai/templates/_helpers.tpl
+++ b/helm/kai/templates/_helpers.tpl
@@ -450,3 +450,25 @@ Registry auth secret name
 {{- define "registry.auth.secretName" -}}
 {{- printf "%s-auth" (include "registry.fullname" . ) -}}
 {{- end -}}
+
+{{/*
+Loki URL
+*/}}
+{{- define "loki.url" -}}
+{{- if .Values.loki.enabled -}}
+    {{- tpl .Values.config.loki.url . | quote -}}
+{{- else -}}
+    {{- .Values.config.loki.url -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Prometheus URL
+*/}}
+{{- define "prometheus.url" -}}
+{{- if .Values.prometheus.enabled -}}
+    {{- tpl .Values.config.prometheus.url . | quote -}}
+{{- else -}}
+    {{- .Values.config.prometheus.url -}}
+{{- end -}}
+{{- end -}}

--- a/helm/kai/templates/engine/admin-api/configmap.yaml
+++ b/helm/kai/templates/engine/admin-api/configmap.yaml
@@ -35,11 +35,11 @@ data:
   KAI_MINIO_TIER_ENABLED: "{{ .Values.config.minio.tier.enabled }}"
   KAI_MINIO_TIER_NAME: {{ include "minio-config.tier.name" . }}
   # Loki
-  KAI_LOKI_ADDRESS: {{ tpl .Values.loki.url . | quote }}
+  KAI_LOKI_ADDRESS: {{ include "loki.url" . }}
   # Prometheus
-  KAI_PROMETHEUS_ADDRESS: {{ tpl .Values.prometheus.url . | quote }}
+  KAI_PROMETHEUS_ADDRESS: {{ include "prometheus.url" . }}
   # Redis
   KAI_REDIS_MASTER_ADDRESS: "{{ include "redis-master.fullname" . }}:{{ .Values.redis.master.service.ports.redis }}"
-  {{- if eq .Values.redis.architecture "replication" }}  
+  {{- if eq .Values.redis.architecture "replication" }}
   KAI_REDIS_REPLICAS_ADDRESS: "{{ include "redis-replicas.fullname" . }}:{{ .Values.redis.replica.service.ports.redis }}"
   {{- end }}

--- a/helm/kai/templates/engine/grafana/datasources-configmap.yaml
+++ b/helm/kai/templates/engine/grafana/datasources-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.grafana.sidecar.datasources.enabled }}
+{{- if and .Values.grafana.enabled .Values.grafana.sidecar.datasources.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -18,13 +18,13 @@ data:
     - name: Loki
       type: loki
       access: proxy
-      url: {{ tpl .Values.loki.url . | quote }}
+      url: {{ include "loki.url" . }}
       version: 1
-      isDefault: {{ default false .Values.loki.isDefault }}
-      {{- with .Values.loki.datasource.uid }}
+      isDefault: {{ default false .Values.config.loki.isDefault }}
+      {{- with .Values.config.loki.datasource.uid }}
       uid: {{ . | quote }}
       {{- end }}
-      {{- with .Values.loki.datasource.jsonData }}
+      {{- with .Values.config.loki.datasource.jsonData }}
       jsonData:
         {{- tpl . $ | nindent 8 }}
       {{- end }}
@@ -34,10 +34,10 @@ data:
     - name: Prometheus
       type: prometheus
       access: proxy
-      url: {{ tpl .Values.prometheus.url . | quote }}
+      url: {{ include "prometheus.url" . }}
       version: 1
-      isDefault: {{ default false .Values.prometheus.isDefault }}
-      {{- with .Values.prometheus.datasource.jsonData }}
+      isDefault: {{ default false .Values.config.prometheus.isDefault }}
+      {{- with .Values.config.prometheus.datasource.jsonData }}
       jsonData:
         {{- tpl . $ | nindent 8 }}
       {{- end }}

--- a/helm/kai/values.yaml
+++ b/helm/kai/values.yaml
@@ -63,6 +63,24 @@ config:
           accessKeyID: ""
           # -- S3 Secret Access Key if no secret is used
           secretAccessKey: ""
+  loki:
+    # -- Only when `loki.enabled: true` and `grafana.enabled: true`. Set loki as default datasource for Grafana.
+    isDefault: true
+    # -- Loki endpoint url. Change this to your own URL when `loki.enabled: false`
+    url: http://{{ include "loki.fullname" .Subcharts.loki }}:{{ .Values.loki.loki.server.http_listen_port }}
+    # -- Only when `loki.enabled: true` and `grafana.enabled: true`. Grafana datasource json data config.
+    datasource:
+      jsonData: "{}"
+      uid: ""
+  prometheus:
+    # -- Only when `prometheus.enabled: true` and `grafana.enabled: true`. Set prometheus as default datasource for Grafana.
+    isDefault: false
+    # -- Prometheus endpoint url. Change this to your own URL when `prometheus.enabled: false`
+    url: http://{{ include "prometheus.fullname" .Subcharts.prometheus }}-{{ .Values.prometheus.server.name }}:{{ .Values.prometheus.server.service.servicePort }}{{ .Values.prometheus.server.prefixURL }}
+    # -- Only when `prometheus.enabled: true` and `grafana.enabled: true`. Grafana datasource json data config.
+    datasource:
+      jsonData: "{}"
+
 adminApi:
   # -- Default application log level
   logLevel: INFO
@@ -863,14 +881,6 @@ grafana:
 loki:
   # -- Whether to enable Loki
   enabled: true
-  # -- Set loki as default datasource
-  isDefault: true
-  # -- Loki endpoint url
-  url: http://{{ include "loki.fullname" .Subcharts.loki }}:{{ .Values.loki.loki.server.http_listen_port }}
-  # -- grafana datasource json data config
-  datasource:
-    jsonData: "{}"
-    uid: ""
   singleBinary:
     replicas: 1
   test:
@@ -928,13 +938,6 @@ loki:
 prometheus:
   # -- Whether to enable Prometheus
   enabled: true
-  # -- Set prometheus as default datasource
-  isDefault: false
-  # -- Prometheus endpoint url
-  url: http://{{ include "prometheus.fullname" .Subcharts.prometheus }}-{{ .Values.prometheus.server.name }}:{{ .Values.prometheus.server.service.servicePort }}{{ .Values.prometheus.server.prefixURL }}
-  # -- grafana datasource json data config
-  datasource:
-    jsonData: "{}"
   ## server configuration
   server:
     # -- name of the prometheus server


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changes in `values.yaml`:
* loki and prometheus `isDefault`, `url` and `datasource` moved to `config.loki` and `config.prometheus` respectively
* `config.loki.url` now requires a valid external URL when `loki.enabled: false`
* `config.prometheus.url` now requires a valid external URL when `prometheus.enabled: false`

## Motivation and Context
We need to make the monitoring stack outsourceable.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other changes (ci configuration, documentation or any other kind of changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have created tests for my code changes, and the tests are passing.
- [X] I have executed the pre-commit hooks locally.
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).
- [X] I have updated the documentation accordingly.
