### PR TITLE
feat(helm): add prometheus config to scrape kai telegraf metrics

### DIFF
--- a/helm/kai/CHART.md
+++ b/helm/kai/CHART.md
@@ -280,10 +280,11 @@
 | prometheus.alertmanager.persistence.size | string | `"2Gi"` | Storage size |
 | prometheus.alertmanager.persistence.storageClass | string | `""` | Storage class name |
 | prometheus.enabled | bool | `true` | Whether to enable Prometheus |
-| prometheus.extraScrapeConfigs | string | `"- job_name: 'kai-service-endpoints'\n  scrape_interval: 1s\n  scrape_timeout: 1s\n  kubernetes_sd_configs:\n  - role: endpoints\n  relabel_configs:\n  - source_labels: [__meta_kubernetes_service_annotation_kai_prometheus_scrape]\n    action: keep\n    regex: true\n  - source_labels: [__meta_kubernetes_service_annotation_kai_prometheus_scheme]\n    action: replace\n    target_label: __scheme__\n    regex: (https?)\n  - source_labels: [__meta_kubernetes_service_annotation_kai_prometheus_path]\n    action: replace\n    target_label: __metrics_path__\n    regex: (.+)\n  - source_labels: [__address__, __meta_kubernetes_service_annotation_kai_prometheus_port]\n    action: replace\n    target_label: __address__\n    regex: ([^:]+)(?::\\d+)?;(\\d+)\n    replacement: $1:$2\n  - source_labels: [__meta_kubernetes_namespace]\n    action: replace\n    target_label: kubernetes_namespace\n  - source_labels: [__meta_kubernetes_service_name]\n    action: replace\n    target_label: kubernetes_service\n  - source_labels: [__meta_kubernetes_pod_name]\n    action: replace\n    target_label: kubernetes_pod\n"` |  |
 | prometheus.kube-state-metrics.enabled | bool | `false` |  |
 | prometheus.prometheus-node-exporter.enabled | bool | `false` |  |
 | prometheus.prometheus-pushgateway.enabled | bool | `false` |  |
+| prometheus.scrapeConfigFiles | list | `["/etc/config/additional-scrape-configs/*.yaml"]` | Files to get additional scrapeConfigs. This allows scrape configs defined in `prometheus.server.extraConfigmapMounts` |
+| prometheus.server.extraConfigmapMounts | list | `[{"configMap":"prometheus-additional-scrape-configs","mountPath":"/etc/config/additional-scrape-configs/","name":"additional-scrape-configs","readOnly":true,"subPath":""}]` | Additional scrape configs for KAI components |
 | prometheus.server.image.tag | string | `"v2.47.2"` | prometheus server version |
 | prometheus.server.ingress.annotations | object | `{}` | Ingress annotations |
 | prometheus.server.ingress.enabled | bool | `true` | Enable ingress for MinIO Web Console |

--- a/helm/kai/CHART.md
+++ b/helm/kai/CHART.md
@@ -64,8 +64,8 @@
 | config.mongodb.connectionString.secretName | string | `""` | The name of the secret that contains a key with the MongoDB connection string. |
 | config.prometheus.datasource | object | `{"jsonData":"{}"}` | Only when `prometheus.enabled: true` and `grafana.enabled: true`. Grafana datasource json data config. |
 | config.prometheus.isDefault | bool | `false` | Only when `prometheus.enabled: true` and `grafana.enabled: true`. Set prometheus as default datasource for Grafana. |
-| config.prometheus.kaiScrapeConfigs | object | `{"configmapName":"prometheus-additional-scrape-configs","enabled":true}` | Enable creation of configmap that contains custom prometheus scrape configs for KAI metrics. Usefull to use with external prometheus instance. |
 | config.prometheus.kaiScrapeConfigs.configmapName | string | `"prometheus-additional-scrape-configs"` | configmap name for additional scrape configs |
+| config.prometheus.kaiScrapeConfigs.enabled | bool | `true` | Enable creation of configmap that contains custom prometheus scrape configs for KAI metrics. Usefull to use with external prometheus instance. If `prometheus.enabled: true` this cannot be disabled |
 | config.prometheus.url | string | `"http://{{ include \"prometheus.fullname\" .Subcharts.prometheus }}-{{ .Values.prometheus.server.name }}:{{ .Values.prometheus.server.service.servicePort }}{{ .Values.prometheus.server.prefixURL }}"` | Prometheus endpoint url. Change this to your own URL when `prometheus.enabled: false` |
 | config.redis.architecture | string | `"standalone"` | architecture. Allowed values: `standalone` or `replication`. Only apply when use your own redis URL/URLs |
 | config.redis.auth.existingSecret | string | `""` | Name of the secret that contains the redis password |

--- a/helm/kai/CHART.md
+++ b/helm/kai/CHART.md
@@ -16,29 +16,29 @@
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| adminApi.affinity | object | `{}` | Assign custom affinity rules to the Admin API pods |
+| adminApi.affinity | object | `{}` | Assign custom affinity rules to the Admin API pods # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # |
 | adminApi.host | string | `"api.kai.local"` | Hostname. This will be used to create the ingress rule and must be a subdomain of `.config.baseDomainName` |
 | adminApi.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | adminApi.image.repository | string | `"konstellation/kai-admin-api"` | Image repository |
-| adminApi.image.tag | string | `"0.2.0-develop.57"` | Image tag |
+| adminApi.image.tag | string | `"0.2.0-develop.59"` | Image tag |
 | adminApi.ingress.annotations | object | See `adminApi.ingress.annotations` in [values.yaml](./values.yaml) | Ingress annotations |
 | adminApi.ingress.className | string | `"kong"` | The name of the ingress class to use |
 | adminApi.logLevel | string | `"INFO"` | Default application log level |
-| adminApi.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. |
+| adminApi.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. # ref: https://kubernetes.io/docs/user-guide/node-selection/ # |
 | adminApi.storage.class | string | `"standard"` | Storage class name |
 | adminApi.storage.path | string | `"/admin-api-files"` | Persistent volume mount point. This will define Admin API app workdir too. |
 | adminApi.storage.size | string | `"1Gi"` | Storage class size |
-| adminApi.tolerations | list | `[]` | Tolerations for use with node taints |
-| chronograf.affinity | object | `{}` | Assign custom affinity rules to the Chronograf pods |
+| adminApi.tolerations | list | `[]` | Tolerations for use with node taints # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ # |
+| chronograf.affinity | object | `{}` | Assign custom affinity rules to the Chronograf pods # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # |
 | chronograf.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | chronograf.image.repository | string | `"chronograf"` | Image repository |
 | chronograf.image.tag | string | `"1.8.4"` | Image tag |
-| chronograf.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. |
+| chronograf.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. # ref: https://kubernetes.io/docs/user-guide/node-selection/ # |
 | chronograf.persistence.accessMode | string | `"ReadWriteOnce"` | Access mode for the volume |
 | chronograf.persistence.enabled | bool | `true` | Whether to enable persistence |
 | chronograf.persistence.size | string | `"2Gi"` | Storage size |
 | chronograf.persistence.storageClass | string | `"standard"` | Storage class name |
-| chronograf.tolerations | list | `[]` | Tolerations for use with node taints |
+| chronograf.tolerations | list | `[]` | Tolerations for use with node taints # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ # |
 | config.admin.corsEnabled | bool | `true` | Whether to enable CORS on Admin API |
 | config.baseDomainName | string | `"kai.local"` | Base domain name for Admin API and K8S Manager apps |
 | config.loki.datasource | object | `{"jsonData":"{}","uid":""}` | Only when `loki.enabled: true` and `grafana.enabled: true`. Grafana datasource json data config. |
@@ -96,22 +96,22 @@
 | grafana.service.type | string | `"ClusterIP"` | Service type |
 | grafana.sidecar | object | `{"datasources":{"enabled":true,"label":"grafana_datasource","labelValue":"1","maxLines":1000}}` | sidecar config (required for datasource config section in loki and prometheus) |
 | influxdb.address | string | `"http://kai-influxdb/"` |  |
-| influxdb.affinity | object | `{}` | Assign custom affinity rules to the InfluxDB pods |
+| influxdb.affinity | object | `{}` | Assign custom affinity rules to the InfluxDB pods # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # |
 | influxdb.config.http | object | `{"auth-enabled":false,"enabled":true,"flux-enabled":true}` | [Details](https://docs.influxdata.com/influxdb/v1.8/administration/config/#http) |
 | influxdb.image.tag | string | `"1.8.1"` | Image tag |
 | influxdb.initScripts.enabled | bool | `true` | Boolean flag to enable and disable initscripts. See https://github.com/influxdata/helm-charts/tree/master/charts/influxdb#configure-the-chart for more info |
 | influxdb.initScripts.scripts | object | `{"init.iql":"CREATE DATABASE \"kai\"\n"}` | Init scripts |
-| influxdb.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. |
+| influxdb.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. # ref: https://kubernetes.io/docs/user-guide/node-selection/ # |
 | influxdb.persistence.accessMode | string | `"ReadWriteOnce"` | Access mode for the volume |
 | influxdb.persistence.enabled | bool | `true` | Whether to enable persistence. See https://github.com/influxdata/helm-charts/tree/master/charts/influxdb#configure-the-chart for more info |
 | influxdb.persistence.size | string | `"10Gi"` | Storage size |
 | influxdb.persistence.storageClass | string | `"standard"` | Storage class name |
-| influxdb.tolerations | list | `[]` | Tolerations for use with node taints |
-| k8sManager.affinity | object | `{}` | Assign custom affinity rules to the K8S Manager pods |
+| influxdb.tolerations | list | `[]` | Tolerations for use with node taints # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ # |
+| k8sManager.affinity | object | `{}` | Assign custom affinity rules to the K8S Manager pods # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # |
 | k8sManager.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | k8sManager.image.repository | string | `"konstellation/kai-k8s-manager"` | Image repository |
-| k8sManager.image.tag | string | `"0.2.0-develop.57"` | Image tag |
-| k8sManager.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. |
+| k8sManager.image.tag | string | `"0.2.0-develop.59"` | Image tag |
+| k8sManager.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. # ref: https://kubernetes.io/docs/user-guide/node-selection/ # |
 | k8sManager.processes.sidecars.fluentbit.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for Fuent Bit sidecar |
 | k8sManager.processes.sidecars.fluentbit.image.repository | string | `"fluent/fluent-bit"` | Image repository for Fuent Bit sidecar |
 | k8sManager.processes.sidecars.fluentbit.image.tag | string | `"2.2.0"` | Image tag for Fuent Bit sidecar |
@@ -123,7 +123,7 @@
 | k8sManager.serviceAccount.annotations | object | `{}` | The Service Account annotations |
 | k8sManager.serviceAccount.create | bool | `true` | Whether to create the Service Account |
 | k8sManager.serviceAccount.name | string | `""` | The name of the service account. @default: A pre-generated name based on the chart relase fullname sufixed by `-k8s-manager` |
-| k8sManager.tolerations | list | `[]` | Tolerations for use with node taints |
+| k8sManager.tolerations | list | `[]` | Tolerations for use with node taints # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ # |
 | kapacitor.enabled | bool | `false` | Whether to enable Kapacitor |
 | kapacitor.persistence.enabled | bool | `false` | Whether to enable persistence [Details](https://github.com/influxdata/helm-charts/blob/master/charts/kapacitor/values.yaml) |
 | keycloak.adminApi.oidcClient.clientId | string | `"admin-cli"` | The name of the OIDC client in Keycloak for the master realm admin |
@@ -229,22 +229,22 @@
 | minio.rootUser | string | Randomly generated value | Sets Root user |
 | minio.service.port | string | `"9000"` | Internal port number for MinIO S3 API service |
 | minio.service.type | string | `"ClusterIP"` | Service type |
-| mongoExpress.affinity | object | `{}` | Assign custom affinity rules to the Mongo Express pods |
+| mongoExpress.affinity | object | `{}` | Assign custom affinity rules to the Mongo Express pods # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # |
 | mongoExpress.connectionString.secretKey | string | `""` | The name of the secret key that contains the MongoDB connection string. |
 | mongoExpress.connectionString.secretName | string | `""` | The name of the secret that contains a key with the MongoDB connection string. |
 | mongoExpress.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | mongoExpress.image.repository | string | `"mongo-express"` | Image repository |
 | mongoExpress.image.tag | string | `"0.54.0"` | Image tag |
-| mongoExpress.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. |
-| mongoExpress.tolerations | list | `[]` | Tolerations for use with node taints |
-| mongoWriter.affinity | object | `{}` | Assign custom affinity rules to the Mongo Writter pods |
+| mongoExpress.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. # ref: https://kubernetes.io/docs/user-guide/node-selection/ # |
+| mongoExpress.tolerations | list | `[]` | Tolerations for use with node taints # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ # |
+| mongoWriter.affinity | object | `{}` | Assign custom affinity rules to the Mongo Writter pods # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # |
 | mongoWriter.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | mongoWriter.image.repository | string | `"konstellation/kai-mongo-writer"` | Image repository |
-| mongoWriter.image.tag | string | `"0.2.0-develop.57"` | Image tag |
-| mongoWriter.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. |
-| mongoWriter.tolerations | list | `[]` | Tolerations for use with node taints |
+| mongoWriter.image.tag | string | `"0.2.0-develop.59"` | Image tag |
+| mongoWriter.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. # ref: https://kubernetes.io/docs/user-guide/node-selection/ # |
+| mongoWriter.tolerations | list | `[]` | Tolerations for use with node taints # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ # |
 | nameOverride | string | `""` | Provide a name in place of kai for `app.kubernetes.io/name` labels |
-| nats.affinity | object | `{}` | Assign custom affinity rules to the NATS pods |
+| nats.affinity | object | `{}` | Assign custom affinity rules to the NATS pods # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # |
 | nats.client.port | int | `4222` | Port for client connections |
 | nats.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | nats.image.repository | string | `"nats"` | Image repository |
@@ -268,11 +268,11 @@
 | nats.logging.debug | bool | `false` | Whether to enable logging debug mode |
 | nats.logging.logtime | bool | `true` | Timestamp log entries |
 | nats.logging.trace | bool | `false` | Whether to enable logging trace mode |
-| nats.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. |
-| nats.tolerations | list | `[]` | Tolerations for use with node taints |
+| nats.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. # ref: https://kubernetes.io/docs/user-guide/node-selection/ # |
+| nats.tolerations | list | `[]` | Tolerations for use with node taints # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ # |
 | natsManager.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | natsManager.image.repository | string | `"konstellation/kai-nats-manager"` | Image repository |
-| natsManager.image.tag | string | `"0.2.0-develop.57"` | Image tag |
+| natsManager.image.tag | string | `"0.2.0-develop.59"` | Image tag |
 | prometheus.alertmanager.enabled | bool | `true` | Whether to enable alertmanager |
 | prometheus.alertmanager.image.tag | string | `"v0.26.0"` | alertmanager server version |
 | prometheus.alertmanager.persistence.accessModes | list | `["ReadWriteOnce"]` | Access mode for the volume |
@@ -280,6 +280,7 @@
 | prometheus.alertmanager.persistence.size | string | `"2Gi"` | Storage size |
 | prometheus.alertmanager.persistence.storageClass | string | `""` | Storage class name |
 | prometheus.enabled | bool | `true` | Whether to enable Prometheus |
+| prometheus.extraScrapeConfigs | string | `"- job_name: 'kai-service-endpoints'\n  scrape_interval: 1s\n  scrape_timeout: 1s\n  kubernetes_sd_configs:\n  - role: endpoints\n  relabel_configs:\n  - source_labels: [__meta_kubernetes_service_annotation_kai_prometheus_scrape]\n    action: keep\n    regex: true\n  - source_labels: [__meta_kubernetes_service_annotation_kai_prometheus_scheme]\n    action: replace\n    target_label: __scheme__\n    regex: (https?)\n  - source_labels: [__meta_kubernetes_service_annotation_kai_prometheus_path]\n    action: replace\n    target_label: __metrics_path__\n    regex: (.+)\n  - source_labels: [__address__, __meta_kubernetes_service_annotation_kai_prometheus_port]\n    action: replace\n    target_label: __address__\n    regex: ([^:]+)(?::\\d+)?;(\\d+)\n    replacement: $1:$2\n  - source_labels: [__meta_kubernetes_namespace]\n    action: replace\n    target_label: kubernetes_namespace\n  - source_labels: [__meta_kubernetes_service_name]\n    action: replace\n    target_label: kubernetes_service\n  - source_labels: [__meta_kubernetes_pod_name]\n    action: replace\n    target_label: kubernetes_pod\n"` |  |
 | prometheus.kube-state-metrics.enabled | bool | `false` |  |
 | prometheus.prometheus-node-exporter.enabled | bool | `false` |  |
 | prometheus.prometheus-pushgateway.enabled | bool | `false` |  |
@@ -326,7 +327,7 @@
 | redis.tls.autoGenerated | bool | `false` | Enable autogenerated certificates |
 | redis.tls.enabled | bool | `false` | Enabled Enable TLS traffic |
 | redis.tls.existingSecret | string | `""` | The name of the existing secret that contains the TLS certificates |
-| registry.affinity | object | `{}` | Assign custom affinity rules to the pods |
+| registry.affinity | object | `{}` | Assign custom affinity rules to the pods # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # |
 | registry.auth.password | string | password | Registry password |
 | registry.auth.user | string | user | Registry username |
 | registry.config | string | `""` | A string contaning the config for Docker Registry. Ref: https://docs.docker.com/registry/configuration/. |
@@ -343,7 +344,7 @@
 | registry.imagePullSecrets | list | `[]` | Image pull secrets |
 | registry.ingress.annotations | object | See `adminApi.ingress.annotations` in [values.yaml](./values.yaml) | Ingress annotations |
 | registry.ingress.className | string | `"kong"` | The name of the ingress class to use |
-| registry.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. |
+| registry.nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. # ref: https://kubernetes.io/docs/user-guide/node-selection/ # |
 | registry.podAnnotations | object | `{}` | Pod annotations |
 | registry.podSecurityContext | object | `{}` | Pod security context |
 | registry.resources | object | `{}` | Container resources |
@@ -358,4 +359,4 @@
 | registry.storage.path | string | `"/var/lib/registry"` | Persistent volume mount point. This will define Registry app workdir too. |
 | registry.storage.size | string | `"10Gi"` | Storage size |
 | registry.storage.storageClass | string | `""` | Storage class name |
-| registry.tolerations | list | `[]` | Tolerations for use with node taints |
+| registry.tolerations | list | `[]` | Tolerations for use with node taints # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ # |

--- a/helm/kai/CHART.md
+++ b/helm/kai/CHART.md
@@ -64,6 +64,8 @@
 | config.mongodb.connectionString.secretName | string | `""` | The name of the secret that contains a key with the MongoDB connection string. |
 | config.prometheus.datasource | object | `{"jsonData":"{}"}` | Only when `prometheus.enabled: true` and `grafana.enabled: true`. Grafana datasource json data config. |
 | config.prometheus.isDefault | bool | `false` | Only when `prometheus.enabled: true` and `grafana.enabled: true`. Set prometheus as default datasource for Grafana. |
+| config.prometheus.kaiScrapeConfigs | object | `{"configmapName":"prometheus-additional-scrape-configs","enabled":true}` | Enable creation of configmap that contains custom prometheus scrape configs for KAI metrics. Usefull to use with external prometheus instance. |
+| config.prometheus.kaiScrapeConfigs.configmapName | string | `"prometheus-additional-scrape-configs"` | configmap name for additional scrape configs |
 | config.prometheus.url | string | `"http://{{ include \"prometheus.fullname\" .Subcharts.prometheus }}-{{ .Values.prometheus.server.name }}:{{ .Values.prometheus.server.service.servicePort }}{{ .Values.prometheus.server.prefixURL }}"` | Prometheus endpoint url. Change this to your own URL when `prometheus.enabled: false` |
 | config.redis.architecture | string | `"standalone"` | architecture. Allowed values: `standalone` or `replication`. Only apply when use your own redis URL/URLs |
 | config.redis.auth.existingSecret | string | `""` | Name of the secret that contains the redis password |
@@ -288,7 +290,7 @@
 | prometheus.prometheus-pushgateway.enabled | bool | `false` |  |
 | prometheus.scrapeConfigFiles | list | `["/etc/config/additional-scrape-configs/*.yaml"]` | Files to get additional scrapeConfigs. This allows scrape configs defined in `prometheus.server.extraConfigmapMounts` |
 | prometheus.server.extraConfigmapMounts[0] | object | `{"configMap":"prometheus-additional-scrape-configs","mountPath":"/etc/config/additional-scrape-configs/","name":"additional-scrape-configs","readOnly":true,"subPath":""}` | name for volumes and volumeMount config |
-| prometheus.server.extraConfigmapMounts[0].configMap | string | `"prometheus-additional-scrape-configs"` | name of the configmap |
+| prometheus.server.extraConfigmapMounts[0].configMap | string | `"prometheus-additional-scrape-configs"` | name of the configmap. Must be the same name set in `config.prometheus.kaiScrapeConfigs.configmapName` |
 | prometheus.server.image.tag | string | `"v2.47.2"` | prometheus server version |
 | prometheus.server.ingress.annotations | object | `{}` | Ingress annotations |
 | prometheus.server.ingress.enabled | bool | `true` | Enable ingress for MinIO Web Console |

--- a/helm/kai/CHART.md
+++ b/helm/kai/CHART.md
@@ -284,7 +284,8 @@
 | prometheus.prometheus-node-exporter.enabled | bool | `false` |  |
 | prometheus.prometheus-pushgateway.enabled | bool | `false` |  |
 | prometheus.scrapeConfigFiles | list | `["/etc/config/additional-scrape-configs/*.yaml"]` | Files to get additional scrapeConfigs. This allows scrape configs defined in `prometheus.server.extraConfigmapMounts` |
-| prometheus.server.extraConfigmapMounts | list | `[{"configMap":"prometheus-additional-scrape-configs","mountPath":"/etc/config/additional-scrape-configs/","name":"additional-scrape-configs","readOnly":true,"subPath":""}]` | Additional scrape configs for KAI components |
+| prometheus.server.extraConfigmapMounts[0] | object | `{"configMap":"prometheus-additional-scrape-configs","mountPath":"/etc/config/additional-scrape-configs/","name":"additional-scrape-configs","readOnly":true,"subPath":""}` | name for volumes and volumeMount config |
+| prometheus.server.extraConfigmapMounts[0].configMap | string | `"prometheus-additional-scrape-configs"` | name of the configmap |
 | prometheus.server.image.tag | string | `"v2.47.2"` | prometheus server version |
 | prometheus.server.ingress.annotations | object | `{}` | Ingress annotations |
 | prometheus.server.ingress.enabled | bool | `true` | Enable ingress for MinIO Web Console |

--- a/helm/kai/templates/_helpers.tpl
+++ b/helm/kai/templates/_helpers.tpl
@@ -114,6 +114,15 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 
+{{/*
+prometheus-additional-scrape-configs labels
+*/}}
+{{- define "prometheus-additional-scrape-configs.labels" -}}
+{{ include "kai.labels" . }}
+app.kubernetes.io/name: {{ include "kai.name" . }}-scrape-configs
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
 {{/* Fullname suffixed with grafana-datasources */}}
 {{- define "grafana-datasources.fullname" -}}
 {{- printf "%s-grafana-datasources" (include "kai.fullname" .) -}}
@@ -124,13 +133,6 @@ grafana-datasources labels
 */}}
 {{- define "grafana-datasources.labels" -}}
 {{ include "kai.labels" . }}
-{{ include "grafana-datasources.selectorLabels" . }}
-{{- end }}
-
-{{/*
-grafana-datasources selector labels
-*/}}
-{{- define "grafana-datasources.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "kai.name" . }}-grafana-datasources
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/helm/kai/templates/engine/prometheus/additional-scrape-configs.yaml
+++ b/helm/kai/templates/engine/prometheus/additional-scrape-configs.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.prometheus.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-additional-scrape-configs
+  labels:
+    {{- include "prometheus-additional-scrape-configs.labels" . | nindent 4 }}
+data:
+  kai-scrape-config.yaml: |
+    scrape_configs:
+    - job_name: kai-service-endpoints
+      scrape_interval: 1s
+      scrape_timeout: 1s
+      kubernetes_sd_configs:
+      - role: endpoints
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_annotation_kai_prometheus_scrape]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_service_annotation_kai_prometheus_scheme]
+        action: replace
+        target_label: __scheme__
+        regex: (https?)
+      - source_labels: [__meta_kubernetes_service_annotation_kai_prometheus_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_service_annotation_kai_prometheus_port]
+        action: replace
+        target_label: __address__
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: kubernetes_namespace
+      - source_labels: [__meta_kubernetes_service_name]
+        action: replace
+        target_label: kubernetes_service
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: kubernetes_pod
+{{- end }}

--- a/helm/kai/templates/engine/prometheus/additional-scrape-configs.yaml
+++ b/helm/kai/templates/engine/prometheus/additional-scrape-configs.yaml
@@ -8,35 +8,35 @@ metadata:
 data:
   kai-scrape-config.yaml: |
     scrape_configs:
-      - job_name: kai-processes-pods
-        scrape_interval: 1s
-        scrape_timeout: 1s
-        kubernetes_sd_configs:
-          - role: pod
-        relabel_configs:
-          - source_labels: [__meta_kubernetes_pod_annotation_kai_prometheus_scrape]
-            action: keep
-            regex: true
-          - source_labels: [__meta_kubernetes_pod_annotation_kai_prometheus_scheme]
-            action: replace
-            target_label: __scheme__
-            regex: (http?)
-          - source_labels: [__meta_kubernetes_pod_annotation_kai_prometheus_path]
-            action: replace
-            target_label: __metrics_path__
-            regex: (.+)
-          - source_labels: [__address__, __meta_kubernetes_pod_annotation_kai_prometheus_port]
-            action: replace
-            target_label: __address__
-            regex: ([^:]+)(?::\d+)?;(\d+)
-            replacement: $1:$2
-          - source_labels: [__meta_kubernetes_namespace]
-            action: replace
-            target_label: kubernetes_namespace
-          - source_labels: [__meta_kubernetes_service_name]
-            action: replace
-            target_label: kubernetes_service
-          - source_labels: [__meta_kubernetes_pod_name]
-            action: replace
-            target_label: kubernetes_pod
-    {{- end }}
+    - job_name: kai-processes-pods
+      scrape_interval: 1s
+      scrape_timeout: 1s
+      kubernetes_sd_configs:
+        - role: pod
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_pod_annotation_kai_prometheus_scrape]
+          action: keep
+          regex: true
+        - source_labels: [__meta_kubernetes_pod_annotation_kai_prometheus_scheme]
+          action: replace
+          target_label: __scheme__
+          regex: (http?)
+        - source_labels: [__meta_kubernetes_pod_annotation_kai_prometheus_path]
+          action: replace
+          target_label: __metrics_path__
+          regex: (.+)
+        - source_labels: [__address__, __meta_kubernetes_pod_annotation_kai_prometheus_port]
+          action: replace
+          target_label: __address__
+          regex: ([^:]+)(?::\d+)?;(\d+)
+          replacement: $1:$2
+        - source_labels: [__meta_kubernetes_namespace]
+          action: replace
+          target_label: kubernetes_namespace
+        - source_labels: [__meta_kubernetes_service_name]
+          action: replace
+          target_label: kubernetes_service
+        - source_labels: [__meta_kubernetes_pod_name]
+          action: replace
+          target_label: kubernetes_pod
+  {{- end }}

--- a/helm/kai/templates/engine/prometheus/additional-scrape-configs.yaml
+++ b/helm/kai/templates/engine/prometheus/additional-scrape-configs.yaml
@@ -20,7 +20,7 @@ data:
       - source_labels: [__meta_kubernetes_service_annotation_kai_prometheus_scheme]
         action: replace
         target_label: __scheme__
-        regex: (https?)
+        regex: (http?)
       - source_labels: [__meta_kubernetes_service_annotation_kai_prometheus_path]
         action: replace
         target_label: __metrics_path__

--- a/helm/kai/templates/engine/prometheus/additional-scrape-configs.yaml
+++ b/helm/kai/templates/engine/prometheus/additional-scrape-configs.yaml
@@ -8,35 +8,35 @@ metadata:
 data:
   kai-scrape-config.yaml: |
     scrape_configs:
-    - job_name: kai-service-endpoints
-      scrape_interval: 1s
-      scrape_timeout: 1s
-      kubernetes_sd_configs:
-      - role: endpoints
-      relabel_configs:
-      - source_labels: [__meta_kubernetes_service_annotation_kai_prometheus_scrape]
-        action: keep
-        regex: true
-      - source_labels: [__meta_kubernetes_service_annotation_kai_prometheus_scheme]
-        action: replace
-        target_label: __scheme__
-        regex: (http?)
-      - source_labels: [__meta_kubernetes_service_annotation_kai_prometheus_path]
-        action: replace
-        target_label: __metrics_path__
-        regex: (.+)
-      - source_labels: [__address__, __meta_kubernetes_service_annotation_kai_prometheus_port]
-        action: replace
-        target_label: __address__
-        regex: ([^:]+)(?::\d+)?;(\d+)
-        replacement: $1:$2
-      - source_labels: [__meta_kubernetes_namespace]
-        action: replace
-        target_label: kubernetes_namespace
-      - source_labels: [__meta_kubernetes_service_name]
-        action: replace
-        target_label: kubernetes_service
-      - source_labels: [__meta_kubernetes_pod_name]
-        action: replace
-        target_label: kubernetes_pod
-{{- end }}
+      - job_name: kai-processes-pods
+        scrape_interval: 1s
+        scrape_timeout: 1s
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_annotation_kai_prometheus_scrape]
+            action: keep
+            regex: true
+          - source_labels: [__meta_kubernetes_pod_annotation_kai_prometheus_scheme]
+            action: replace
+            target_label: __scheme__
+            regex: (http?)
+          - source_labels: [__meta_kubernetes_pod_annotation_kai_prometheus_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_kai_prometheus_port]
+            action: replace
+            target_label: __address__
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+          - source_labels: [__meta_kubernetes_namespace]
+            action: replace
+            target_label: kubernetes_namespace
+          - source_labels: [__meta_kubernetes_service_name]
+            action: replace
+            target_label: kubernetes_service
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: kubernetes_pod
+    {{- end }}

--- a/helm/kai/templates/engine/prometheus/additional-scrape-configs.yaml
+++ b/helm/kai/templates/engine/prometheus/additional-scrape-configs.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.prometheus.enabled }}
+{{- if and .Values.prometheus.enabled .Values.config.prometheus.kaiScrapeConfigs.enabled}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: prometheus-additional-scrape-configs
+  name: {{ .Values.config.prometheus.kaiScrapeConfigs.configmapName }}
   labels:
     {{- include "prometheus-additional-scrape-configs.labels" . | nindent 4 }}
 data:

--- a/helm/kai/templates/engine/prometheus/additional-scrape-configs.yaml
+++ b/helm/kai/templates/engine/prometheus/additional-scrape-configs.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.prometheus.enabled .Values.config.prometheus.kaiScrapeConfigs.enabled}}
+{{- if or .Values.prometheus.enabled .Values.config.prometheus.kaiScrapeConfigs.enabled}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/kai/values.yaml
+++ b/helm/kai/values.yaml
@@ -993,6 +993,13 @@ prometheus:
         - ReadWriteOnce
       # -- Storage size
       size: 2Gi
+    # -- Additional scrape configs for KAI components
+    extraConfigmapMounts:
+      - name: additional-scrape-configs
+        mountPath: /etc/config/additional-scrape-configs/
+        subPath: ""
+        configMap: prometheus-additional-scrape-configs
+        readOnly: true
     service:
       # -- Service type
       type: ClusterIP
@@ -1012,39 +1019,9 @@ prometheus:
         - prometheus.kai.local
       # -- Ingress TLS configuration
       tls: []
-  ## -- Define extra scrape configs for kai components
-  extraScrapeConfigs: |
-    - job_name: 'kai-service-endpoints'
-      scrape_interval: 1s
-      scrape_timeout: 1s
-      kubernetes_sd_configs:
-      - role: endpoints
-      relabel_configs:
-      - source_labels: [__meta_kubernetes_service_annotation_kai_prometheus_scrape]
-        action: keep
-        regex: true
-      - source_labels: [__meta_kubernetes_service_annotation_kai_prometheus_scheme]
-        action: replace
-        target_label: __scheme__
-        regex: (https?)
-      - source_labels: [__meta_kubernetes_service_annotation_kai_prometheus_path]
-        action: replace
-        target_label: __metrics_path__
-        regex: (.+)
-      - source_labels: [__address__, __meta_kubernetes_service_annotation_kai_prometheus_port]
-        action: replace
-        target_label: __address__
-        regex: ([^:]+)(?::\d+)?;(\d+)
-        replacement: $1:$2
-      - source_labels: [__meta_kubernetes_namespace]
-        action: replace
-        target_label: kubernetes_namespace
-      - source_labels: [__meta_kubernetes_service_name]
-        action: replace
-        target_label: kubernetes_service
-      - source_labels: [__meta_kubernetes_pod_name]
-        action: replace
-        target_label: kubernetes_pod
+  # -- Files to get additional scrapeConfigs. This allows scrape configs defined in `prometheus.server.extraConfigmapMounts`
+  scrapeConfigFiles:
+  - /etc/config/additional-scrape-configs/*.yaml
   ## Alertmanager complete values https://github.com/prometheus-community/helm-charts/tree/main/charts/alertmanager
   alertmanager:
     # -- Whether to enable alertmanager

--- a/helm/kai/values.yaml
+++ b/helm/kai/values.yaml
@@ -100,8 +100,9 @@ config:
     # -- Only when `prometheus.enabled: true` and `grafana.enabled: true`. Grafana datasource json data config.
     datasource:
       jsonData: "{}"
-    # -- Enable creation of configmap that contains custom prometheus scrape configs for KAI metrics. Usefull to use with external prometheus instance.
+    ## Scrape configs used by KAI
     kaiScrapeConfigs:
+      # -- Enable creation of configmap that contains custom prometheus scrape configs for KAI metrics. Usefull to use with external prometheus instance. If `prometheus.enabled: true` this cannot be disabled
       enabled: true
       # -- configmap name for additional scrape configs
       configmapName: prometheus-additional-scrape-configs

--- a/helm/kai/values.yaml
+++ b/helm/kai/values.yaml
@@ -1012,6 +1012,39 @@ prometheus:
         - prometheus.kai.local
       # -- Ingress TLS configuration
       tls: []
+  ## -- Define extra scrape configs for kai components
+  extraScrapeConfigs: |
+    - job_name: 'kai-service-endpoints'
+      scrape_interval: 1s
+      scrape_timeout: 1s
+      kubernetes_sd_configs:
+      - role: endpoints
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_annotation_kai_prometheus_scrape]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_service_annotation_kai_prometheus_scheme]
+        action: replace
+        target_label: __scheme__
+        regex: (https?)
+      - source_labels: [__meta_kubernetes_service_annotation_kai_prometheus_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_service_annotation_kai_prometheus_port]
+        action: replace
+        target_label: __address__
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: kubernetes_namespace
+      - source_labels: [__meta_kubernetes_service_name]
+        action: replace
+        target_label: kubernetes_service
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: kubernetes_pod
   ## Alertmanager complete values https://github.com/prometheus-community/helm-charts/tree/main/charts/alertmanager
   alertmanager:
     # -- Whether to enable alertmanager

--- a/helm/kai/values.yaml
+++ b/helm/kai/values.yaml
@@ -100,6 +100,11 @@ config:
     # -- Only when `prometheus.enabled: true` and `grafana.enabled: true`. Grafana datasource json data config.
     datasource:
       jsonData: "{}"
+    # -- Enable creation of configmap that contains custom prometheus scrape configs for KAI metrics. Usefull to use with external prometheus instance.
+    kaiScrapeConfigs:
+      enabled: true
+      # -- configmap name for additional scrape configs
+      configmapName: prometheus-additional-scrape-configs
 adminApi:
   # -- Default application log level
   logLevel: INFO
@@ -1007,7 +1012,7 @@ prometheus:
       - name: additional-scrape-configs
         mountPath: /etc/config/additional-scrape-configs/
         subPath: ""
-        # -- name of the configmap
+        # -- name of the configmap. Must be the same name set in `config.prometheus.kaiScrapeConfigs.configmapName`
         configMap: prometheus-additional-scrape-configs
         readOnly: true
     service:

--- a/helm/kai/values.yaml
+++ b/helm/kai/values.yaml
@@ -993,11 +993,13 @@ prometheus:
         - ReadWriteOnce
       # -- Storage size
       size: 2Gi
-    # -- Additional scrape configs for KAI components
+    ## Additional scrape configs for KAI telegraf metrics
     extraConfigmapMounts:
+      # -- name for volumes and volumeMount config
       - name: additional-scrape-configs
         mountPath: /etc/config/additional-scrape-configs/
         subPath: ""
+        # -- name of the configmap
         configMap: prometheus-additional-scrape-configs
         readOnly: true
     service:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Configure Prometheus to scrape the given tag names:
```
  annotations:
    kai.prometheus/scrape: "true"
    kai.prometheus/scheme: "https"
    kai.prometheus/path: "/metrics"
    kai.prometheus/port: "9191"
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other changes (ci configuration, documentation or any other kind of changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have created tests for my code changes, and the tests are passing.
- [x] I have executed the pre-commit hooks locally.
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).
- [ ] I have updated the documentation accordingly.
