### PR TITLE
Fix/ci test and release triggers

### DIFF
--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -6,6 +6,8 @@ on:
       - develop
       - 'release/**'
       - 'hotfix/**'
+    tags-ignore:
+      - '*'
   pull_request:
     paths:
       - 'engine/**/*'
@@ -17,6 +19,8 @@ on:
 
 jobs:
   check-folder-changes:
+    # Avoid running when Nyx commits changes
+    if: ${{ !contains(github.event.head_commit.message, 'Release version') }}
     runs-on: ubuntu-latest
     name: Check folder changes
     outputs:
@@ -42,6 +46,8 @@ jobs:
             - '.github/workflows/test-release.yaml'
 
   unit-tests:
+    # Avoid running when Nyx commits changes
+    if: ${{ !contains(github.event.head_commit.message, 'Release version') }}
     runs-on: ubuntu-latest
     name: Linting and Unit tests
     needs: check-folder-changes
@@ -90,6 +96,8 @@ jobs:
             engine/${{ matrix.component }}/coverage-integration.out
 
   sonarcloud:
+    # Avoid running when Nyx commits changes
+    if: ${{ !contains(github.event.head_commit.message, 'Release version') }}
     name: SonarCloud
     runs-on: ubuntu-latest
     needs:
@@ -130,6 +138,8 @@ jobs:
           SONAR_TOKEN: ${{ secrets[matrix.sonar_token_secret] }}
 
   release-version:
+    # Avoid running when Nyx commits changes
+    if: ${{ !contains(github.event.head_commit.message, 'Release version') }}
     name: Publish the release (if any) with Nyx
     needs: SonarCloud
     runs-on: ubuntu-latest
@@ -192,6 +202,8 @@ jobs:
         GH_TOKEN: ${{ secrets.PAT }}
 
   publish-chart:
+    # Avoid running when Nyx commits changes
+    if: ${{ !contains(github.event.head_commit.message, 'Release version') }}
     name: Publish the chart
     runs-on: ubuntu-latest
     needs: release-version


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR workarounds the issue Nyx produces when Chart Releaser generates a new tag (kai-x.y.z) after a new stable release is published.

After the backmerge to `develop` branch Nyx always infers the latest tag is `kai-x.y.z` and therefore it tries to publish the latest `x.y.z` tag which it already exists. Example:

All current changes are merged into `main`-> Nyx publishes the `0.2.0` tag and Chart Releaser publshes the `kay-0.2.0` tag at the same time -> Backmerge from `main` to `develop` -> The backmerge changes triggers the **Test and Release** workflow that executes Nyx again -> Determines that the `0.2.0` tag needs to be published again

Check https://github.com/konstellation-io/kai/actions/runs/7503635090/job/20428907644#step:5:11

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other changes (ci configuration, documentation or any other kind of changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have created tests for my code changes, and the tests are passing.
- [ ] I have executed the pre-commit hooks locally.
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).
- [ ] I have updated the documentation accordingly.
