### PR TITLE
feat: add custom errors to get product version

### DIFF
--- a/engine/admin-api/domain/usecase/version/errors.go
+++ b/engine/admin-api/domain/usecase/version/errors.go
@@ -17,6 +17,7 @@ const (
 var (
 	ErrParsingKRTFile             = errors.New("error parsing KRT file")
 	ErrVersionNotFound            = errors.New("error version not found")
+	ErrProductExistsNoVersions    = errors.New("error product exists but has no versions")
 	ErrVersionDuplicated          = errors.New("error version duplicated")
 	ErrUserNotAuthorized          = errors.New("error user not authorized")
 	ErrVersionCannotBeStarted     = errors.New("error version cannot be started, status must be 'created', 'stopped', 'publishing' or 'error'")

--- a/engine/admin-api/domain/usecase/version/get_by_tag.go
+++ b/engine/admin-api/domain/usecase/version/get_by_tag.go
@@ -9,7 +9,12 @@ import (
 
 // GetByTag returns a Version by its unique tag.
 func (h *Handler) GetByTag(ctx context.Context, user *entity.User, productID, tag string) (*entity.Version, error) {
-	err := h.accessControl.CheckProductGrants(user, productID, auth.ActViewProduct)
+	_, err := h.productRepo.GetByID(ctx, productID)
+	if err != nil {
+		return nil, err
+	}
+
+	err = h.accessControl.CheckProductGrants(user, productID, auth.ActViewProduct)
 	if err != nil {
 		return nil, err
 	}

--- a/engine/admin-api/domain/usecase/version/get_by_tag_test.go
+++ b/engine/admin-api/domain/usecase/version/get_by_tag_test.go
@@ -8,10 +8,12 @@ import (
 
 	"github.com/konstellation-io/kai/engine/admin-api/domain/entity"
 	"github.com/konstellation-io/kai/engine/admin-api/domain/service/auth"
+	"github.com/konstellation-io/kai/engine/admin-api/domain/usecase"
+	"github.com/konstellation-io/kai/engine/admin-api/domain/usecase/version"
 	"github.com/konstellation-io/kai/engine/admin-api/testhelpers"
 )
 
-func (s *versionSuite) TestGetByTag() {
+func (s *versionSuite) TestGetByTag_OK() {
 	// GIVEN
 	var (
 		ctx         = context.Background()
@@ -20,6 +22,7 @@ func (s *versionSuite) TestGetByTag() {
 		testVersion = testhelpers.NewVersionBuilder().WithTag("test-tag").Build()
 	)
 
+	s.productRepo.EXPECT().GetByID(ctx, productID).Return(&entity.Product{}, nil)
 	s.accessControl.EXPECT().CheckProductGrants(user, productID, auth.ActViewProduct).Return(nil)
 	s.versionRepo.EXPECT().GetByTag(ctx, productID, testVersion.Tag).Return(testVersion, nil)
 
@@ -29,6 +32,23 @@ func (s *versionSuite) TestGetByTag() {
 	// THEN
 	s.Require().NoError(err)
 	s.Equal(testVersion, actual)
+}
+
+func (s *versionSuite) TestGetByTag_ProductNotFound() {
+	// GIVEN
+	var (
+		user      = testhelpers.NewUserBuilder().Build()
+		productID = "product-1"
+		ctx       = context.Background()
+	)
+
+	s.productRepo.EXPECT().GetByID(ctx, productID).Return(nil, usecase.ErrProductNotFound)
+
+	// WHEN
+	_, err := s.handler.GetByTag(ctx, user, productID, "test-tag")
+
+	// THEN
+	s.ErrorIs(err, usecase.ErrProductNotFound)
 }
 
 func (s *versionSuite) TestGetByTag_Unauthorized() {
@@ -41,6 +61,7 @@ func (s *versionSuite) TestGetByTag_Unauthorized() {
 		expectedErr = errors.New("unauthorized")
 	)
 
+	s.productRepo.EXPECT().GetByID(ctx, productID).Return(&entity.Product{}, nil)
 	s.accessControl.EXPECT().CheckProductGrants(user, productID, auth.ActViewProduct).Return(expectedErr)
 
 	// WHEN
@@ -48,6 +69,26 @@ func (s *versionSuite) TestGetByTag_Unauthorized() {
 
 	// THEN
 	s.ErrorIs(err, expectedErr)
+}
+
+func (s *versionSuite) TestGetByTag_VersionNotFound() {
+	// GIVEN
+	var (
+		ctx         = context.Background()
+		user        = testhelpers.NewUserBuilder().Build()
+		productID   = "product-1"
+		testVersion = testhelpers.NewVersionBuilder().WithTag("test-tag").Build()
+	)
+
+	s.productRepo.EXPECT().GetByID(ctx, productID).Return(&entity.Product{}, nil)
+	s.accessControl.EXPECT().CheckProductGrants(user, productID, auth.ActViewProduct).Return(nil)
+	s.versionRepo.EXPECT().GetByTag(ctx, productID, testVersion.Tag).Return(nil, version.ErrVersionNotFound)
+
+	// WHEN
+	_, err := s.handler.GetByTag(ctx, user, productID, testVersion.Tag)
+
+	// THEN
+	s.ErrorIs(err, version.ErrVersionNotFound)
 }
 
 func (s *versionSuite) TestGetByTag_PublishedVersion_PublishedTriggers() {
@@ -65,6 +106,7 @@ func (s *versionSuite) TestGetByTag_PublishedVersion_PublishedTriggers() {
 		}
 	)
 
+	s.productRepo.EXPECT().GetByID(ctx, productID).Return(&entity.Product{}, nil)
 	s.accessControl.EXPECT().CheckProductGrants(user, productID, auth.ActViewProduct).Return(nil)
 	s.versionRepo.EXPECT().GetByTag(ctx, productID, testVersion.Tag).Return(testVersion, nil)
 	s.versionService.EXPECT().GetPublishedTriggers(ctx, productID).Return(expectedPublishedTriggers, nil)
@@ -75,4 +117,29 @@ func (s *versionSuite) TestGetByTag_PublishedVersion_PublishedTriggers() {
 	// THEN
 	s.Require().NoError(err)
 	s.Equal(expectedPublishedTriggers, actual.PublishedTriggers)
+}
+
+func (s *versionSuite) TestGetByTag_PublishedVersion_ErrorGettingPublishedTriggers() {
+	// GIVEN
+	var (
+		ctx         = context.Background()
+		user        = testhelpers.NewUserBuilder().Build()
+		productID   = "product-1"
+		testVersion = testhelpers.NewVersionBuilder().
+				WithTag("test-tag").
+				WithStatus(entity.VersionStatusPublished).
+				Build()
+		expectedErr = errors.New("error getting published triggers")
+	)
+
+	s.productRepo.EXPECT().GetByID(ctx, productID).Return(&entity.Product{}, nil)
+	s.accessControl.EXPECT().CheckProductGrants(user, productID, auth.ActViewProduct).Return(nil)
+	s.versionRepo.EXPECT().GetByTag(ctx, productID, testVersion.Tag).Return(testVersion, nil)
+	s.versionService.EXPECT().GetPublishedTriggers(ctx, productID).Return(nil, expectedErr)
+
+	// WHEN
+	_, err := s.handler.GetByTag(ctx, user, productID, testVersion.Tag)
+
+	// THEN
+	s.ErrorIs(err, expectedErr)
 }

--- a/engine/admin-api/domain/usecase/version/get_latest.go
+++ b/engine/admin-api/domain/usecase/version/get_latest.go
@@ -8,5 +8,15 @@ import (
 
 // GetLatest returns a the latest created version of a product.
 func (h *Handler) GetLatest(ctx context.Context, user *entity.User, productID string) (*entity.Version, error) {
-	return h.versionRepo.GetLatest(ctx, productID)
+	_, err := h.productRepo.GetByID(ctx, productID)
+	if err != nil {
+		return nil, err
+	}
+
+	ver, err := h.versionRepo.GetLatest(ctx, productID)
+	if err != nil {
+		return nil, ErrProductExistsNoVersions
+	}
+
+	return ver, nil
 }

--- a/engine/admin-api/domain/usecase/version/get_latest_test.go
+++ b/engine/admin-api/domain/usecase/version/get_latest_test.go
@@ -5,19 +5,61 @@ package version_test
 import (
 	"context"
 
+	"github.com/konstellation-io/kai/engine/admin-api/domain/entity"
+	"github.com/konstellation-io/kai/engine/admin-api/domain/usecase"
+	"github.com/konstellation-io/kai/engine/admin-api/domain/usecase/version"
 	"github.com/konstellation-io/kai/engine/admin-api/testhelpers"
 )
 
-func (s *versionSuite) TestGetLatest() {
-	// GIVEN a productID and a version tag
-	productID := "product-1"
-	ctx := context.Background()
-	testVersion := testhelpers.NewVersionBuilder().WithTag("test-tag").Build()
+func (s *versionSuite) TestGetLatest_OK() {
+	// GIVEN
+	var (
+		user        = testhelpers.NewUserBuilder().Build()
+		productID   = "product-1"
+		ctx         = context.Background()
+		testVersion = testhelpers.NewVersionBuilder().WithTag("test-tag").Build()
+	)
 
+	s.productRepo.EXPECT().GetByID(ctx, productID).Return(&entity.Product{}, nil)
 	s.versionRepo.EXPECT().GetLatest(ctx, productID).Return(testVersion, nil)
 
-	actual, err := s.versionRepo.GetLatest(ctx, productID)
+	actual, err := s.handler.GetLatest(ctx, user, productID)
 	s.Require().NoError(err)
 
 	s.Equal(testVersion, actual)
+}
+
+func (s *versionSuite) TestGetLatest_ProductNotFound() {
+	// GIVEN
+	var (
+		user      = testhelpers.NewUserBuilder().Build()
+		productID = "product-1"
+		ctx       = context.Background()
+	)
+
+	s.productRepo.EXPECT().GetByID(ctx, productID).Return(nil, usecase.ErrProductNotFound)
+
+	// WHEN
+	_, err := s.handler.GetLatest(ctx, user, productID)
+
+	// THEN
+	s.ErrorIs(err, usecase.ErrProductNotFound)
+}
+
+func (s *versionSuite) TestGetLatest_VersionNotFoundWithExistingProduct() {
+	// GIVEN
+	var (
+		user      = testhelpers.NewUserBuilder().Build()
+		productID = "product-1"
+		ctx       = context.Background()
+	)
+
+	s.productRepo.EXPECT().GetByID(ctx, productID).Return(&entity.Product{}, nil)
+	s.versionRepo.EXPECT().GetLatest(ctx, productID).Return(nil, version.ErrProductExistsNoVersions)
+
+	// WHEN
+	_, err := s.handler.GetLatest(ctx, user, productID)
+
+	// THEN
+	s.ErrorIs(err, version.ErrProductExistsNoVersions)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
added custom errors when retrieving a version

this is to inform kai of the following scenario: a product exists but no versions have been created, so the kli needs to create an empty version when binding

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other changes (ci configuration, documentation or any other kind of changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have created tests for my code changes, and the tests are passing.
- [ ] I have executed the pre-commit hooks locally.
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).
- [ ] I have updated the documentation accordingly.
